### PR TITLE
Add glide package manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 metrics
 bin
+vendor
 
 /**/google_deployment.env
 codeship.aes

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,108 @@
+hash: 88c592a7dfec818fe9a47615e63cfc1e0a84cdd9068afaa26b58a08c4f2e50f2
+updated: 2017-04-11T16:55:30.533019143+05:30
+imports:
+- name: cloud.google.com/go
+  version: 1180f1d0d05f61a65f39b3b9be37815493758d2f
+  subpackages:
+  - compute/metadata
+  - iam
+  - internal/version
+  - pubsub
+  - pubsub/apiv1
+- name: github.com/golang/protobuf
+  version: 2bba0603135d7d7f5cb73b2125beeda19c09f4ef
+  subpackages:
+  - proto
+  - protoc-gen-go/descriptor
+  - ptypes
+  - ptypes/any
+  - ptypes/duration
+  - ptypes/empty
+  - ptypes/timestamp
+- name: github.com/googleapis/gax-go
+  version: 9af46dd5a1713e8b5cd71106287eba3cefdde50b
+- name: github.com/replaygaming/amplitude
+  version: b98b7a35c7cbad8ea454630f6e003603521056c0
+- name: github.com/replaygaming/consumer
+  version: 33f730ad2bd4d175c478503016ab80c6d424caf3
+- name: github.com/replaygaming/go-metrics
+  version: 0d88959872adaa23f2ca8f6a79a5005950d3b421
+  subpackages:
+  - internal/amplitude
+- name: golang.org/x/net
+  version: d1e1b351919c6738fdeb9893d5c998b161464f0c
+  subpackages:
+  - context
+  - context/ctxhttp
+  - http2
+  - http2/hpack
+  - idna
+  - internal/timeseries
+  - lex/httplex
+  - trace
+- name: golang.org/x/oauth2
+  version: 7fdf09982454086d5570c7db3e11f360194830ca
+  subpackages:
+  - google
+  - internal
+  - jws
+  - jwt
+- name: golang.org/x/sync
+  version: 5a06fca2c336a4b2b2fcb45702e8c47621b2aa2c
+  subpackages:
+  - semaphore
+- name: golang.org/x/text
+  version: f4b4367115ec2de254587813edaa901bc1c723a8
+  subpackages:
+  - secure/bidirule
+  - transform
+  - unicode/bidi
+  - unicode/norm
+- name: google.golang.org/api
+  version: 48e49d1645e228d1c50c3d54fb476b2224477303
+  subpackages:
+  - googleapi/transport
+  - internal
+  - iterator
+  - option
+  - support/bundler
+  - transport
+- name: google.golang.org/appengine
+  version: 170382fa85b10b94728989dfcf6cc818b335c952
+  subpackages:
+  - internal
+  - internal/app_identity
+  - internal/base
+  - internal/datastore
+  - internal/log
+  - internal/modules
+  - internal/remote_api
+  - internal/socket
+  - internal/urlfetch
+  - socket
+  - urlfetch
+- name: google.golang.org/genproto
+  version: 411e09b969b1170a9f0c467558eb4c4c110d9c77
+  subpackages:
+  - googleapis/api/annotations
+  - googleapis/iam/v1
+  - googleapis/pubsub/v1
+  - googleapis/rpc/status
+  - protobuf/field_mask
+- name: google.golang.org/grpc
+  version: ff17eeb5f6e2112ef30f103d686fa725ee31202e
+  subpackages:
+  - codes
+  - credentials
+  - credentials/oauth
+  - grpclog
+  - internal
+  - keepalive
+  - metadata
+  - naming
+  - peer
+  - stats
+  - status
+  - tap
+  - transport
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,8 @@
+package: .
+import:
+- package: github.com/replaygaming/amplitude
+- package: github.com/replaygaming/consumer
+- package: github.com/replaygaming/go-metrics
+  version: ^0.5.0-rc2
+  subpackages:
+  - internal/amplitude


### PR DESCRIPTION
Glide is package manager for go, similar to npm for node, and supports package specification in yaml file.
More on Glide here: https://glide.readthedocs.io/en/latest/